### PR TITLE
Fixes

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -12,6 +12,6 @@ mod_menu_version=3.0.0
 halplibe_version=5.2.4
 
 # Mod
-mod_version=3.0.1-7.3_03
+mod_version=3.0.2+7.3_03
 mod_group=luke
 mod_name=stardew

--- a/src/main/java/luke/stardew/blocks/BlockLogicLeavesSeasonal.java
+++ b/src/main/java/luke/stardew/blocks/BlockLogicLeavesSeasonal.java
@@ -1,5 +1,6 @@
 package luke.stardew.blocks;
 
+import luke.stardew.StardewMod;
 import net.minecraft.core.block.Block;
 import net.minecraft.core.block.BlockLogicLeavesBase;
 import net.minecraft.core.block.material.Material;
@@ -19,14 +20,14 @@ public class BlockLogicLeavesSeasonal extends BlockLogicLeavesBase {
 	}
 
 	@Override
-	protected Block<?> getSapling() {
+	public Block<?> getSapling() {
 		return saplingSupplier.get();
 	}
 
 	@Override
 	public void animationTick(World world, int x, int y, int z, Random rand) {
 		if (world.seasonManager.getCurrentSeason() != null && world.seasonManager.getCurrentSeason() == Seasons.OVERWORLD_WINTER && rand.nextInt(40) == 0) {
-			world.spawnParticle("fallingleaf", x, (double) y - 0.10000000149011612, z, 0.0, 0.0, 0.0, 0);
+			world.spawnParticle(StardewMod.MOD_ID + "$fallingleaf", x, (double) y - 0.10000000149011612, z, 0.0, 0.0, 0.0, 0);
 		}
 	}
 }

--- a/src/main/java/luke/stardew/blocks/BlockLogicLeavesSeasonal.java
+++ b/src/main/java/luke/stardew/blocks/BlockLogicLeavesSeasonal.java
@@ -4,20 +4,29 @@ import net.minecraft.core.block.Block;
 import net.minecraft.core.block.BlockLogicLeavesBase;
 import net.minecraft.core.block.material.Material;
 import net.minecraft.core.world.World;
-import net.minecraft.core.world.season.Season;
 import net.minecraft.core.world.season.Seasons;
+import org.jetbrains.annotations.NotNull;
 
 import java.util.Random;
+import java.util.function.Supplier;
 
 public class BlockLogicLeavesSeasonal extends BlockLogicLeavesBase {
+	protected @NotNull Supplier<Block<?>> saplingSupplier;
 
-	public BlockLogicLeavesSeasonal(Block<?> block, Block<?> sapling) {
-		super(block, Material.leaves, sapling);
+	public BlockLogicLeavesSeasonal(Block<?> block, @NotNull Supplier<Block<?>> sapling) {
+		super(block, Material.leaves, null);
+		this.saplingSupplier = sapling;
 	}
 
-	public void randomDisplayTick(World world, int x, int y, int z, Random rand) {
+	@Override
+	protected Block<?> getSapling() {
+		return saplingSupplier.get();
+	}
+
+	@Override
+	public void animationTick(World world, int x, int y, int z, Random rand) {
 		if (world.seasonManager.getCurrentSeason() != null && world.seasonManager.getCurrentSeason() == Seasons.OVERWORLD_WINTER && rand.nextInt(40) == 0) {
-			world.spawnParticle("fallingleaf", x, (double)y - 0.10000000149011612, z, 0.0, 0.0, 0.0, 0);
+			world.spawnParticle("fallingleaf", x, (double) y - 0.10000000149011612, z, 0.0, 0.0, 0.0, 0);
 		}
 	}
 }

--- a/src/main/java/luke/stardew/blocks/BlockLogicLeavesSeasonalFlowering.java
+++ b/src/main/java/luke/stardew/blocks/BlockLogicLeavesSeasonalFlowering.java
@@ -13,12 +13,13 @@ import net.minecraft.core.world.World;
 import net.minecraft.core.world.season.Seasons;
 
 import java.util.Random;
+import java.util.function.Supplier;
 
 public class BlockLogicLeavesSeasonalFlowering extends BlockLogicLeavesSeasonal implements IBonemealable {
 
 	private final Item fruitItem;
 
-	public BlockLogicLeavesSeasonalFlowering(Block<?> block, Block<?> sapling, Item fruitItem) {
+	public BlockLogicLeavesSeasonalFlowering(Block<?> block, Supplier<Block<?>> sapling, Item fruitItem) {
 		super(block, sapling);
 		this.fruitItem = fruitItem;
 	}

--- a/src/main/java/luke/stardew/blocks/StardewBlocks.java
+++ b/src/main/java/luke/stardew/blocks/StardewBlocks.java
@@ -197,18 +197,18 @@ public class StardewBlocks {
 		LOG_APPLE = log
 			.build("log_apple", blockID("LOG_APPLE"), b -> new BlockLogicLog(b));
 		LEAVES_APPLE = leaves
-			.build("leaves_apple", blockID("LEAVES_APPLE"), b -> new BlockLogicLeavesSeasonal(b, StardewBlocks.SAPLING_APPLE));
+			.build("leaves_apple", blockID("LEAVES_APPLE"), b -> new BlockLogicLeavesSeasonal(b, () -> SAPLING_APPLE));
 		LEAVES_APPLE_FLOWERING = leaves
-			.build("leaves_apple_flowering", blockID("LEAVES_APPLE_FLOWERING"), b -> new BlockLogicLeavesSeasonalFlowering(b, StardewBlocks.SAPLING_APPLE, Items.FOOD_APPLE));
+			.build("leaves_apple_flowering", blockID("LEAVES_APPLE_FLOWERING"), b -> new BlockLogicLeavesSeasonalFlowering(b, () -> SAPLING_APPLE, Items.FOOD_APPLE));
 		SAPLING_APPLE = sapling
 			.build("sapling_apple", blockID("SAPLING_APPLE"), b -> new BlockLogicSaplingSeasonal(b, LOG_APPLE, LEAVES_APPLE, LEAVES_APPLE_FLOWERING, 5));
 
 		LOG_APPLE_GOLDEN = log
 			.build("log_apple_golden", blockID("LOG_APPLE_GOLDEN"), b -> new BlockLogicLog(b));
 		LEAVES_APPLE_GOLDEN = leaves
-			.build("leaves_apple_golden", blockID("LEAVES_APPLE_GOLDEN"), b -> new BlockLogicLeavesSeasonal(b, SAPLING_APPLE_GOLDEN));
+			.build("leaves_apple_golden", blockID("LEAVES_APPLE_GOLDEN"), b -> new BlockLogicLeavesSeasonal(b, () -> SAPLING_APPLE_GOLDEN));
 		LEAVES_APPLE_GOLDEN_FLOWERING = leaves
-			.build("leaves_apple_golden_flowering", blockID("LEAVES_APPLE_GOLDEN_FLOWERING"), b -> new BlockLogicLeavesSeasonalFlowering(b, SAPLING_APPLE_GOLDEN, Items.FOOD_APPLE_GOLD));
+			.build("leaves_apple_golden_flowering", blockID("LEAVES_APPLE_GOLDEN_FLOWERING"), b -> new BlockLogicLeavesSeasonalFlowering(b, () -> SAPLING_APPLE_GOLDEN, Items.FOOD_APPLE_GOLD));
 		SAPLING_APPLE_GOLDEN = sapling
 			.build("sapling_apple_golden", blockID("SAPLING_APPLE_GOLDEN"), b -> new BlockLogicSaplingSeasonal(b, LOG_APPLE_GOLDEN, LEAVES_APPLE_GOLDEN, LEAVES_APPLE_GOLDEN_FLOWERING, 20));
 

--- a/src/main/java/luke/stardew/particles/ParticleLeafStardew.java
+++ b/src/main/java/luke/stardew/particles/ParticleLeafStardew.java
@@ -1,0 +1,40 @@
+package luke.stardew.particles;
+
+import luke.stardew.StardewMod;
+import luke.stardew.blocks.BlockLogicLeavesSeasonal;
+import luke.stardew.blocks.StardewBlocks;
+import net.minecraft.client.entity.particle.ParticleLeaf;
+import net.minecraft.client.render.texture.stitcher.TextureRegistry;
+import net.minecraft.core.block.Block;
+import net.minecraft.core.block.BlockLogicLeavesBase;
+import net.minecraft.core.util.helper.MathHelper;
+import net.minecraft.core.world.World;
+
+public class ParticleLeafStardew extends ParticleLeaf {
+	public ParticleLeafStardew(World world, double x, double y, double z, double xa, double ya, double za) {
+		super(world, x, y, z, xa, ya, za);
+
+		init(MathHelper.floor(x), MathHelper.floor(y), MathHelper.floor(z));
+	}
+
+	@Override
+	public ParticleLeaf init(int x, int y, int z) {
+		if (world == null) return this;
+
+		Block<?> block = world.getBlock(x, y, z);
+		if (!Block.hasLogicClass(block, BlockLogicLeavesBase.class)) {
+			this.remove();
+		}
+
+		if (block != null && block.getLogic() instanceof BlockLogicLeavesSeasonal) { // Very hacky awful mess I hate particles
+			if (((BlockLogicLeavesSeasonal) block.getLogic()).getSapling() == StardewBlocks.SAPLING_APPLE) {
+				tex = TextureRegistry.getTexture(StardewMod.MOD_ID + ":block/leaves_apple_fancy");
+			}else {
+				tex = TextureRegistry.getTexture(StardewMod.MOD_ID + ":block/leaves_apple_golden_fancy");
+			}
+
+		}
+
+		return this; //Skip color fetching
+	}
+}


### PR DESCRIPTION
## Changes
- Fixed leaves not having their saplings properly initialized resulting in a crash
- Reverted version string to include a `+` separator for the BTA version rather than a `-` as this would log a version syntax error on launch (the plus sign is used to signify metadata and will not affect version precedence)
- Fixed leaf particles not spawning
- Bumped version from 3.0.1 to 3.0.2